### PR TITLE
Using Field.default instead of Field.missing_value to compute initial value of tile data

### DIFF
--- a/plone/tiles/data.py
+++ b/plone/tiles/data.py
@@ -94,7 +94,7 @@ class PersistentTileDataManager(object):
         if self.tileType is not None and self.tileType.schema is not None:
             for name, field in getFields(self.tileType.schema).items():
                 if name not in data:
-                    data[name] = field.missing_value
+                    data[name] = field.bind(self.tileType).default
         return data
 
     def set(self, data):

--- a/plone/tiles/tiles.rst
+++ b/plone/tiles/tiles.rst
@@ -361,7 +361,7 @@ We also need a context that is annotatable.
 Now, let's create a persistent tile with a schema.
 
     >>> class IPersistentSampleData(Interface):
-    ...     text = zope.schema.Text(title=u"Detailed text", missing_value=u"Missing!")
+    ...     text = zope.schema.Text(title=u"Detailed text", default=u"Missing!")
 
     >>> from plone.tiles import PersistentTile
     >>> class PersistentSampleTile(PersistentTile):


### PR DESCRIPTION
We might want to use default value of a field using default property. It also enables defaultFactory computation using zope.schema._bootstrapfields.DefaultProperty
