### PR TITLE
Fix missing view permissions info on tiletype registration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Let TileType instances (tile registration utility) know about the view permission too.
+  [jensens]
 
 
 1.5.2 (2016-03-28)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-1.5.3 (unreleased)
-------------------
+1.6 (unreleased)
+----------------
 
 - Let TileType instances (tile registration utility) know about the view permission too.
   [jensens]

--- a/README.rst
+++ b/README.rst
@@ -169,11 +169,12 @@ When registering a tile, in the background two registrations are done:
 
    - ``name`` (required)
    - ``title`` (required)
-   - ``description``
+   - ``description`` (optional)
    - ``icon`` (optional)
-   - ``add_permission`` (required)
-   - ``edit_permission`` (optional)
-   - ``delete_permission`` (optional)
+   - ``permission`` (required)
+   - ``add_permission`` (required for adding capabilities)
+   - ``edit_permission`` (optional, default to add_permission)
+   - ``delete_permission`` (optional, default to add_permission)
    - ``schema`` (optional)
 
 2) How to **render** the tile (as a usal page).
@@ -185,8 +186,8 @@ When registering a tile, in the background two registrations are done:
    - ``name`` (required)
    - ``for`` (optional)
    - ``layer`` (optional)
-   - ``class`` (this or template or both is required)
-   - ``template`` (this or template or both is required)
+   - ``class`` (this or ``template`` or both is required)
+   - ``template`` (this or ``class`` or both is required)
    - ``permission`` (required)
 
 The **directives attributes** have the following meaning:

--- a/plone/tiles/directives.rst
+++ b/plone/tiles/directives.rst
@@ -17,7 +17,7 @@ To make it easier to register these components, this package provides a
 To test this, we have created a dummy schema and a dummy tile in ``tests.py``,
 and a dummy template in ``test.pt``.
 
-Let's show how these may be used by registering several tiles:
+Let's show how these may be used by registering several tiles::
 
     >>> configuration = """\
     ... <configure package="plone.tiles"
@@ -103,7 +103,7 @@ Let's show how these may be used by registering several tiles:
     >>> from zope.configuration import xmlconfig
     >>> xmlconfig.xmlconfig(StringIO(configuration))
 
-Let's check how the tiles were registered:
+Let's check how the tiles were registered::
 
     >>> from zope.component import getUtility
     >>> from plone.tiles.interfaces import ITileType
@@ -116,6 +116,9 @@ Let's check how the tiles were registered:
 
     >>> tile1_type.add_permission
     'plone.tiles.tests.DummyAdd'
+
+    >>> tile1_type.view_permission
+    'plone.tiles.tests.DummyView'
 
     >>> tile1_type.schema
     <InterfaceClass plone.tiles.tests.IDummySchema>
@@ -150,7 +153,7 @@ Let's check how the tiles were registered:
     >>> tile4_type.schema
     <InterfaceClass plone.tiles.tests.IDummySchema>
 
-Finally, let's check that we can look up the tiles.
+Finally, let's check that we can look up the tiles::
 
     >>> from zope.publisher.browser import TestRequest
     >>> from zope.interface import implements, alsoProvides

--- a/plone/tiles/esi.rst
+++ b/plone/tiles/esi.rst
@@ -60,6 +60,7 @@ registered via ZCML.
     ...     title=u"Sample tile",
     ...     description=u"A tile used for testing",
     ...     add_permission="dummy.Permission",
+    ...     view_permission="dummy.Permission",
     ...     schema=None)
 
     >>> from zope.component import provideAdapter, provideUtility
@@ -217,6 +218,7 @@ attribute to the ZCML directive will work also.
     ...     title=u"Sample ESI tile",
     ...     description=u"A tile used for testing ESI",
     ...     add_permission="dummy.Permission",
+    ...     view_permission="dummy.Permission",
     ...     schema=None)
 
     >>> provideUtility(sampleESITileType, name=u'sample.esitile')

--- a/plone/tiles/meta.py
+++ b/plone/tiles/meta.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 from plone.tiles.interfaces import ITileType
 from plone.tiles.tile import Tile
 from plone.tiles.type import TileType
@@ -23,6 +22,7 @@ class ITileDirective(Interface):
     name = schema.DottedName(
         title=u"Name",
         description=u"A unique, dotted name for the tile",
+        required=True,
     )
 
     title = MessageID(
@@ -93,7 +93,7 @@ class ITileDirective(Interface):
     permission = Permission(
         title=u"View permission",
         description=u"Name of the permission required to view this item",
-        required=False,
+        required=True,
     )
 
 
@@ -103,7 +103,6 @@ def tile(_context, name, title=None, description=None, icon=None,
          permission=None):
     """Implements the <plone:tile /> directive
     """
-
     if (
         title is not None or
         description is not None or
@@ -115,8 +114,17 @@ def tile(_context, name, title=None, description=None, icon=None,
             raise ConfigurationError(
                 u"When configuring a new type of tile, 'title' and "
                 u"'add_permission' are required")
-        type_ = TileType(name, title, add_permission, edit_permission,
-                         delete_permission, description, icon, schema)
+        type_ = TileType(
+            name,
+            title,
+            add_permission,
+            permission,
+            edit_permission=edit_permission,
+            delete_permission=delete_permission,
+            description=description,
+            icon=icon,
+            schema=schema
+        )
 
         utility(_context, provides=ITileType, component=type_, name=name)
 
@@ -124,16 +132,12 @@ def tile(_context, name, title=None, description=None, icon=None,
         for_ is not None or
         layer is not None or
         class_ is not None or
-        template is not None or
-        permission is not None
+        template is not None
     ):
         if class_ is None and template is None:
             raise ConfigurationError(
                 u"'class' or 'template' must be given when configuring a tile."
             )
-        if permission is None:
-            raise ConfigurationError(
-                u"When configuring a tile, 'permission' is required")
 
         if for_ is None:
             for_ = Interface

--- a/plone/tiles/tests.py
+++ b/plone/tiles/tests.py
@@ -45,7 +45,8 @@ class PloneTiles(Layer):
     def setUp(self):
         import plone.tiles
         self['configurationContext'] = context = zca.stackConfigurationContext(
-            self.get('configurationContext'))
+            self.get('configurationContext')
+        )
         xmlconfig.file('configure.zcml', plone.tiles, context=context)
 
     def tearDown(self):

--- a/plone/tiles/tiles.rst
+++ b/plone/tiles/tiles.rst
@@ -76,10 +76,11 @@ using the ``<plone:tile />`` directive. Here's how to create one manually:
 
     >>> from plone.tiles.type import TileType
     >>> sampleTileType = TileType(
-    ...     name=u'sample.tile',
-    ...     title=u"Sample tile",
+    ...     u'sample.tile',
+    ...     u"Sample tile",
+    ...     "dummy.Permission",
+    ...     "dummy.Permission",
     ...     description=u"A tile used for testing",
-    ...     add_permission="dummy.Permission",
     ...     schema=None)
 
 The name should match the view name and the name the utility is registered
@@ -372,10 +373,11 @@ Now, let's create a persistent tile with a schema.
     ...         return u"<b>You said</b> %s" % self.data['text']
 
     >>> persistentSampleTileType = TileType(
-    ...     name=u'sample.persistenttile',
-    ...     title=u"Persistent sample tile",
+    ...     u'sample.persistenttile',
+    ...     u"Persistent sample tile",
+    ...     "dummy.Permission",
+    ...     "dummy.Permission",
     ...     description=u"A tile used for testing",
-    ...     add_permission="dummy.Permission",
     ...     schema=IPersistentSampleData)
 
     >>> provideUtility(persistentSampleTileType, name=u'sample.persistenttile')

--- a/plone/tiles/type.py
+++ b/plone/tiles/type.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 from plone.tiles.interfaces import ITileType
 from zope.interface import implementer
 
@@ -9,9 +8,18 @@ class TileType(object):
     """A utility that describes a type of tile
     """
 
-    def __init__(self, name, title, add_permission, edit_permission=None,
-                 delete_permission=None, description=None, icon=None,
-                 schema=None):
+    def __init__(
+        self,
+        name,
+        title,
+        add_permission,
+        view_permission,
+        edit_permission=None,
+        delete_permission=None,
+        description=None,
+        icon=None,
+        schema=None
+    ):
 
         if delete_permission is None:
             delete_permission = add_permission
@@ -23,6 +31,7 @@ class TileType(object):
         self.title = title
         self.add_permission = add_permission
         self.edit_permission = edit_permission
+        self.view_permission = view_permission
         self.delete_permission = delete_permission
         self.description = description
         self.icon = icon

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     open(os.path.join("plone", "tiles", "tiles.rst")).read() + "\n" +
     open(os.path.join("plone", "tiles", "directives.rst")).read() + "\n" +
     open(os.path.join("plone", "tiles", "esi.rst")).read() + "\n" +
-    open("CHANGELOG.rst").read(),
+    open("CHANGES.rst").read(),
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 import os
 
 
-version = '1.5.3.dev0'
+version = '1.6.dev0'
 
 setup(
     name='plone.tiles',


### PR DESCRIPTION
The registration utility dis not know about the view permission. 

In order to fix an issue with plone.app.tiles rendering via subrequest the permission has to be known before the actual rendering happens. this enables such a check (and does not hurt anyway, could be handy in other use cases as well).