### PR TITLE
Add overridable tiledata storage layer to allow custom tile data storages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-1.6.2 (unreleased)
+1.7.0 (unreleased)
 ------------------
 
 Breaking changes:
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Add support for custom storage layer with ITileDataStorage adapter
+  [datakurre]
 
 Bug fixes:
 

--- a/plone/tiles/configure.zcml
+++ b/plone/tiles/configure.zcml
@@ -7,6 +7,8 @@
     <adapter factory=".data.transientTileDataManagerFactory" />
     <adapter factory=".data.PersistentTileDataManager" />
     <adapter factory=".data.defaultTileDataContext" />
+    <adapter factory=".data.defaultTileDataStorage" />
+    <adapter factory=".data.defaultPersistentTileDataStorage" />
 
     <!-- Absolute URL -->
     <view

--- a/plone/tiles/interfaces.py
+++ b/plone/tiles/interfaces.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-
 from zope.interface import Interface
+from zope.interface.common.mapping import IMapping
 from zope.interface.interfaces import IInterface
 from zope.publisher.interfaces.browser import IBrowserView
 
@@ -146,8 +146,21 @@ class ITileDataContext(Interface):
     the context or request.
 
     The default implementation simply returns ``tile.context``. That must
-    be annotatable for the default persistent tile ``ITileDataManager``
-    to work.
+    be annotatable for the default tile data storage adapter and
+    persistent tile ``ITileDataManager`` to work.
+    """
+
+
+class ITileDataStorage(IMapping):
+    """Indirection to help determine how persistent tiles store their data.
+
+    This is a multi-adapter on ``(context, request, tile)``. The context and
+    request are the same as ``tile.context`` and ``tile.request``, but these
+    discriminators allow the data context to be customised depending on
+    the context or request.
+
+    The default implementation simply returns the configured zope.annotation
+    storage for the given context.
     """
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 import os
 
 
-version = '1.6.2.dev0'
+version = '1.7.0.dev0'
 
 setup(
     name='plone.tiles',


### PR DESCRIPTION
This would allow the feature we discussed with @jensens at Mephisto sprint. Because plone.tiles is not aware of plone.app.blocks, plone.tiles still defaults to its current default storages: url for transient and annotations for persistent.

This would adds a few indirections, which would allow to customize the storage layer later, as done in the relate pull for plone.app.blocks.

This change itself should not have backwards compatibility issues.