### PR TITLE
Change datamanager getter to fallback to persistent storage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 1.8.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+Bug fixes:
+
+- Allow data fallback, if tile changes its storage strategy
+  from persistent to another stragey
+  [tomgross]
 
 
 1.8.2 (2017-01-10)

--- a/plone/tiles/data.py
+++ b/plone/tiles/data.py
@@ -55,7 +55,7 @@ class TransientTileDataManager(object):
             (self.context, tile.request, tile), ITileDataStorage)
 
         self.persistent_key = '.'.join([ANNOTATIONS_KEY_PREFIX, str(tile.id)])
-        self.persistent_storage = defaultPersistentTileDataStorage(self.context, tile.request, tile)
+        self.persistent_storage = IAnnotations(self.context, {})
         if IAnnotations.providedBy(self.storage):
             self.key = self.persistent_key
         else:


### PR DESCRIPTION
Fixes one part of https://github.com/plone/plone.app.mosaic/issues/332 

 - [x] PersistentTile -> Tile
 - [ ] Tile -> PersistentTile (this case needs to live at least in plone.app.blocks, since the layoutaware storage is defined there)
