### PR TITLE
Fix ESI support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,17 +4,24 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
-Bug fixes:
+Breaking changes:
 
-- Fix issue where ESI tile helper views didn't get correct
-  Cache-Control-headers, because ESI helpers views were not acquisition
-  wrapped
+- Tile traversal no longer adds ``X-Tile-Url``-header with absolute URL.
+  Relative ``X-Tile-Url`` is still set, but only after successful rendering
+  of tile (in default view class ``__call__``).
   [datakurre]
 
 New features:
 
 - Added X-Frame-Options -header for ESI tile views with matching behavior
   with plone.protect
+  [datakurre]
+
+Bug fixes:
+
+- Fix issue where ESI tile helper views didn't get correct
+  Cache-Control-headers, because ESI helpers views were not acquisition
+  wrapped
   [datakurre]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,21 +6,21 @@ Changelog
 
 Breaking changes:
 
-- Tile traversal no longer adds ``X-Tile-Url``-header with absolute URL.
-  Relative ``X-Tile-Url`` is still set, but only after successful rendering
-  of tile (in default view class ``__call__``).
+- Tiles no longer add relative ``X-Tile-Url``-header in ``__call__``.
+  Tiles still add absolute ``X-Tile-Url``-header during traversal, but
+  it is removed after rendering if request is not CSRF-authorized.
   [datakurre]
 
 New features:
 
-- Added X-Frame-Options -header for ESI tile views with matching behavior
+- Added X-Frame-Options -header for ESI-tile views with matching behavior
   with plone.protect
   [datakurre]
 
 Bug fixes:
 
-- Fix issue where ESI tile helper views didn't get correct
-  Cache-Control-headers, because ESI helpers views were not acquisition
+- Fix issue where ESI-tile helper views didn't get correct
+  Cache-Control-headers, because ESI-helpers views were not acquisition
   wrapped
   [datakurre]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,11 @@ Breaking changes:
 
 - Tiles no longer add relative ``X-Tile-Url``-header in ``__call__``.
   Tiles still add absolute ``X-Tile-Url``-header during traversal, but
-  it is removed after rendering if request is not CSRF-authorized.
+  it gest removed after rendering when request is not CSRF-authorized.
+  [datakurre]
+
+- Generic ESI helper do now check the request is authorized to render
+  the tile according to the registered view permission fo the tile.
   [datakurre]
 
 New features:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,21 @@
 Changelog
 =========
 
-1.8.3 (unreleased)
+2.0.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+Bug fixes:
+
+- Fix issue where ESI tile helper views didn't get correct
+  Cache-Control-headers, because ESI helpers views were not acquisition
+  wrapped
+  [datakurre]
+
+New features:
+
+- Added X-Frame-Options -header for ESI tile views with matching behavior
+  with plone.protect
+  [datakurre]
 
 
 1.8.2 (2017-01-10)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,11 +8,24 @@ Breaking changes:
 
 - Tiles no longer add relative ``X-Tile-Url``-header in ``__call__``.
   Tiles still add absolute ``X-Tile-Url``-header during traversal, but
-  it gest removed after rendering when request is not CSRF-authorized.
+  it gets removed after rendering when request is not CSRF-authorized.
   [datakurre]
 
-- Generic ESI helper do now check the request is authorized to render
+- Generic ESI helper check now taht the request is authorized to render
   the tile according to the registered view permission fo the tile.
+  [datakurre]
+
+- Transactions of requests to ESI helper views are automatically aborted,
+  because ESI requests should always be immutable GET requests
+  [datakurre]
+
+- plone.app.theming (transform) is now disabled with X-Theme-Disabled-header
+  for requests rendering tiles
+  [datakurre]
+
+- plone.protect's ProtectTransform is skipped for tile requests with correct
+  CSRF token prevent its side-effects on tile editors rendering tiles
+  individually
   [datakurre]
 
 New features:

--- a/plone/tiles/configure.zcml
+++ b/plone/tiles/configure.zcml
@@ -77,6 +77,16 @@
         zcml:condition="installed plone.transformchain"
         />
 
+    <configure zcml:condition="installed plone.protect">
+      <adapter
+        name="plone.tiles.tileurl"
+        provides="plone.transformchain.interfaces.ITransform"
+        for=".tile.Tile *"
+        factory=".tile.TileUrlTransform"
+        zcml:condition="installed plone.transformchain"
+      />
+    </configure>
+
     <!-- Field Type converters -->
     <adapter for="zope.schema.interfaces.IBytesLine"
              factory="plone.tiles.fieldtypeconverters.NoConverter"

--- a/plone/tiles/configure.zcml
+++ b/plone/tiles/configure.zcml
@@ -1,6 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="plone.tiles">
 
     <!-- Data manager -->
@@ -58,6 +59,22 @@
         for=".interfaces.IESIRendered"
         class=".esi.ESIBody"
         permission="zope.Public"
+        />
+
+    <adapter
+        name="plone.protect.autocsrf"
+        provides="plone.transformchain.interfaces.ITransform"
+        for=".esi.ESIHead *"
+        factory=".esi.ESIProtectTransform"
+        zcml:condition="installed plone.transformchain"
+        />
+
+    <adapter
+        name="plone.protect.autocsrf"
+        provides="plone.transformchain.interfaces.ITransform"
+        for=".esi.ESIBody *"
+        factory=".esi.ESIProtectTransform"
+        zcml:condition="installed plone.transformchain"
         />
 
     <!-- Field Type converters -->

--- a/plone/tiles/configure.zcml
+++ b/plone/tiles/configure.zcml
@@ -77,12 +77,20 @@
         zcml:condition="installed plone.transformchain"
         />
 
-    <configure zcml:condition="installed plone.protect">
-      <adapter
-        name="plone.tiles.tileurl"
+    <adapter
+        name="plone.protect.autocsrf"
         provides="plone.transformchain.interfaces.ITransform"
         for=".tile.Tile *"
-        factory=".tile.TileUrlTransform"
+        factory=".tile.TileProtectTransform"
+        zcml:condition="installed plone.transformchain"
+        />
+
+    <configure zcml:condition="installed plone.protect">
+      <adapter
+        name="plone.tiles.tiletheming"
+        provides="plone.transformchain.interfaces.ITransform"
+        for=".tile.Tile *"
+        factory=".tile.TileThemingTransform"
         zcml:condition="installed plone.transformchain"
       />
     </configure>

--- a/plone/tiles/esi.py
+++ b/plone/tiles/esi.py
@@ -62,7 +62,7 @@ class ConditionalESIRendering(object):
             if self.head:
                 mode = 'esi-head'
             return ESI_TEMPLATE.format(
-                url=self.request.getURL(),
+                url=self.request.get('PATH_INFO') or self.request.getURL(),
                 queryString=self.request.get('QUERY_STRING', ''),
                 esiMode=mode
             )

--- a/plone/tiles/esi.py
+++ b/plone/tiles/esi.py
@@ -2,10 +2,14 @@
 from plone.tiles.interfaces import ESI_HEADER
 from plone.tiles.interfaces import ESI_HEADER_KEY
 from plone.tiles.interfaces import IESIRendered
+from plone.tiles.interfaces import ITileType
 from plone.tiles.tile import PersistentTile
 from plone.tiles.tile import Tile
 from Products.Five import BrowserView
+from zExceptions import Unauthorized
+from zope.component import queryUtility
 from zope.interface import implementer
+from zope.security import checkPermission
 
 import re
 import os
@@ -107,6 +111,15 @@ class ESIHead(BrowserView):
     def __call__(self):
         """Return the children of the <head> tag as a fragment.
         """
+        # Check for the registered view permission
+        try:
+            type_ = queryUtility(ITileType, self.context.__name__)
+            permission = type_.view_permission
+        except AttributeError:
+            permission = None
+        if permission:
+            if not checkPermission(permission, self.context):
+                raise Unauthorized()
 
         if self.request.getHeader(ESI_HEADER):
             del self.request.environ[ESI_HEADER_KEY]
@@ -129,6 +142,15 @@ class ESIBody(BrowserView):
     def __call__(self):
         """Return the children of the <head> tag as a fragment.
         """
+        # Check for the registered view permission
+        try:
+            type_ = queryUtility(ITileType, self.context.__name__)
+            permission = type_.view_permission
+        except AttributeError:
+            permission = None
+        if permission:
+            if not checkPermission(permission, self.context):
+                raise Unauthorized()
 
         if self.request.getHeader(ESI_HEADER):
             del self.request.environ[ESI_HEADER_KEY]

--- a/plone/tiles/esi.py
+++ b/plone/tiles/esi.py
@@ -183,6 +183,7 @@ class ESIProtectTransform(object):
         self.request = request
 
     def transform(self, result, encoding):
+        from plone.protect.interfaces import IDisableCSRFProtection
         # clickjacking protection from plone.protect
         if X_FRAME_OPTIONS:
             if not self.request.response.getHeader('X-Frame-Options'):
@@ -192,7 +193,9 @@ class ESIProtectTransform(object):
         if 'x-tile-url' in self.request.response.headers:
             del self.request.response.headers['x-tile-url']
         # ESI requests are always GET request and should not mutate DB
-        transaction.abort()
+        # unless they provide IDisableCSRFProtection
+        if not IDisableCSRFProtection.providedBy(self.request):
+            transaction.abort()
         return None
 
     def transformBytes(self, result, encoding):

--- a/plone/tiles/esi.py
+++ b/plone/tiles/esi.py
@@ -14,8 +14,9 @@ try:
 except ImportError:
     from zope.security import checkPermission
 
-import re
 import os
+import re
+import transaction
 
 X_FRAME_OPTIONS = os.environ.get('PLONE_X_FRAME_OPTIONS', 'SAMEORIGIN')
 
@@ -190,6 +191,8 @@ class ESIProtectTransform(object):
         # drop X-Tile-Url
         if 'x-tile-url' in self.request.response.headers:
             del self.request.response.headers['x-tile-url']
+        # ESI requests are always GET request and should not mutate DB
+        transaction.abort()
         return None
 
     def transformBytes(self, result, encoding):

--- a/plone/tiles/esi.py
+++ b/plone/tiles/esi.py
@@ -9,7 +9,10 @@ from Products.Five import BrowserView
 from zExceptions import Unauthorized
 from zope.component import queryUtility
 from zope.interface import implementer
-from zope.security import checkPermission
+try:
+    from AccessControl.security import checkPermission
+except ImportError:
+    from zope.security import checkPermission
 
 import re
 import os

--- a/plone/tiles/esi.rst
+++ b/plone/tiles/esi.rst
@@ -59,6 +59,8 @@ Ordinarily, of course, it would be registered via ZCML.
 .. code-block:: python
 
     >>> from plone.tiles.type import TileType
+    >>> from zope.security.permission import Permission
+    >>> permission = Permission('dummy.Permission')
     >>> sampleTileType = TileType(
     ...     name=u'sample.tile',
     ...     title=u'Sample tile',
@@ -71,6 +73,7 @@ Ordinarily, of course, it would be registered via ZCML.
     >>> from zope.interface import Interface
     >>> from plone.tiles.interfaces import IBasicTile
 
+    >>> provideUtility(permission, name=u'dummy.Permission')
     >>> provideUtility(sampleTileType, name=u'sample.tile')
     >>> provideAdapter(SampleTile, (Interface, Interface), IBasicTile, name=u'sample.tile')
 
@@ -139,6 +142,16 @@ At this point, we can look up the ESI views:
 .. code-block:: python
 
     >>> head = getMultiAdapter((tile, request), name='esi-head')
+    >>> head()
+    Traceback (most recent call last):
+    ...
+    Unauthorized: Unauthorized()
+
+But we can only render them when we have the required permissions:
+
+    >>> from AccessControl.SecurityManagement import newSecurityManager
+    >>> from AccessControl.User import UnrestrictedUser
+    >>> newSecurityManager(None, UnrestrictedUser('manager', '', ['Manager'], []))
     >>> print head()
     <title>Title</title>
 

--- a/plone/tiles/testing.py
+++ b/plone/tiles/testing.py
@@ -38,10 +38,12 @@ class PloneTiles(Layer):
     defaultBases = (z2.STARTUP,)
 
     def setUp(self):
-        import plone.tiles
         self['configurationContext'] = context = zca.stackConfigurationContext(
             self.get('configurationContext')
         )
+        import zope.annotation
+        xmlconfig.file('configure.zcml', zope.annotation, context=context)
+        import plone.tiles
         xmlconfig.file('configure.zcml', plone.tiles, context=context)
 
     def tearDown(self):

--- a/plone/tiles/tile.py
+++ b/plone/tiles/tile.py
@@ -46,11 +46,6 @@ class Tile(BrowserView):
             if self.__doc__ is None:
                 self.__doc__ = 'For Zope 2, to keep the ZPublisher happy'
 
-            self.request.response.setHeader(
-                'X-Tile-Url',
-                self.url
-            )
-
             return self
 
         # Also allow views on tiles even without @@.
@@ -82,12 +77,17 @@ class Tile(BrowserView):
                 u'Override __call__ or set a class variable "index" to point '
                 u'to a view page template file'
             )
+
+        # Rendering tile may raise Unauthorized exception
+        output = self.index(*args, **kwargs)
+
+        # X-Tile-Url is set only after tile has been successfully rendered
         if self.id is not None:
             self.request.response.setHeader(
                 'X-Tile-Url',
                 self.url[len(self.context.absolute_url()) + 1:]
             )
-        return self.index(*args, **kwargs)
+        return output
 
     @property
     def data(self):

--- a/plone/tiles/tile.py
+++ b/plone/tiles/tile.py
@@ -2,9 +2,9 @@
 from plone.tiles.interfaces import IPersistentTile
 from plone.tiles.interfaces import ITile
 from plone.tiles.interfaces import ITileDataManager
+from Products.Five import BrowserView
 from zope.component import queryMultiAdapter
 from zope.interface import implementer
-from zope.publisher.browser import BrowserView
 from zope.traversing.browser.absoluteurl import absoluteURL
 
 

--- a/plone/tiles/tiles.rst
+++ b/plone/tiles/tiles.rst
@@ -154,9 +154,13 @@ and verify how the tile is instantiated.
 .. code-block:: python
 
     >>> from zope.component import getMultiAdapter
+    >>> from zope.interface import classImplements
     >>> from zope.interface import Interface
     >>> from zope.interface import implementer
     >>> from zope.publisher.browser import TestRequest
+    >>> from zope.annotation.interfaces import IAnnotations
+    >>> from zope.annotation.interfaces import IAttributeAnnotatable
+    >>> classImplements(TestRequest, IAttributeAnnotatable)
 
     >>> class IContext(Interface):
     ...     pass
@@ -531,7 +535,6 @@ Yet, just adding the flag, doesn't create new persistent annotations on GET requ
     >>> sorted(ITileDataManager(tile).get().items(), key=lambda x: x[0])
     [('count', 5), ('cssClass', 'foo'), ('title', u'My title')]
 
-    >>> from zope.annotation.interfaces import IAnnotations
     >>> list(IAnnotations(context).keys())
     []
 


### PR DESCRIPTION
This might need review with care and would result in plone.tiles >= 2.0.

* Being able to cache ESI helper views, they need to be acquisition aware, requiring me to change base classes of Tile and ESI helper views to Products.Five.BrowserView

* ESI views must override plone.protect's transforms to mostly skip it, because ESI tiles must not be wrapped with html-tag (or include protect.js), which lxml's HTML parser seem to do otherwise. Not sure, if there's a way to fix that in plone.protect. On the other and ESI transactions can always be aborted.

* Currently Tile traversal ay reveal tile configuration in X-Tile-Url-header even when the request is not authorized to render the request. That's because X-Tile-Url must be set already during traversal when possible authorization is not known. My current Mosaic compatible fix here is that I remove X-Tile-Url in a new plone.transformchain transform when request does not carry proper CSRF token.

* Currently, ESI helper views public (yet, the are only registered for tiles providing IESIRendered). They probably must be to be generic and re-usable with custom tiles, but here I add check for the view_permission of the current tile into ESI helper views ``__call__``.

* Theming must be disabled for tiles to avoid possible-side-effects for layout editors

* ProtectTransform must be skipped when tiles are rendered in layout editors to avoid side-effects there (like a dozens of protect.js requests), but this is only done when CSRF token is valid (without CSRF token, the transform is still called)