### PR TITLE
Fix issue where it was not possibly to POST a query string value for a primary field

### DIFF
--- a/news/30.bugfix
+++ b/news/30.bugfix
@@ -1,0 +1,1 @@
+Fixed issue where creating a Mosaic page with shared content layout with filled rich text fields ended up having empty rich text fields, because the rich text field is marked primary (as it should be), and primary fields were never parsed from query string by default.

--- a/plone/tiles/data.py
+++ b/plone/tiles/data.py
@@ -357,7 +357,7 @@ def decode(data, schema, missing=True, primary=False):
 
     If primary is True, also fields that are marged as primary fields are
     decoded from the data. (Primary fields are not decoded by default,
-    because primary field are mainly used for rich text or binary fields 
+    because primary field are mainly used for rich text or binary fields
     and data is usually parsed from query string with length limitations.)
     """
 

--- a/plone/tiles/data.py
+++ b/plone/tiles/data.py
@@ -64,7 +64,8 @@ class BaseTileDataManager(object):
             # Try to decode the form data properly if we can
             try:
                 data = decode(self.tile.request.form,
-                              self.tileType.schema, missing=True)
+                              self.tileType.schema,
+                              missing=True, primary=True)
             except (ValueError, UnicodeDecodeError,):
                 LOGGER.exception(u'Could not convert form data to schema')
                 return self.data.copy()
@@ -342,7 +343,7 @@ def encode(data, schema, ignore=()):
 
 # Decoding
 
-def decode(data, schema, missing=True):
+def decode(data, schema, missing=True, primary=False):
     """Decode a data dict according to a schema. The returned dictionary will
     contain only keys matching schema names, and will force type values
     appropriately.
@@ -353,12 +354,17 @@ def decode(data, schema, missing=True):
 
     If missing is True, fields that are in the schema but not in the data will
     be set to field.missing_value. Otherwise, they are ignored.
+
+    If primary is True, also fields that are marged as primary fields are
+    decoded from the data. (Primary fields are not decoded by default,
+    because primary field are mainly used for rich text or binary fields 
+    and data is usually parsed from query string with length limitations.)
     """
 
     decoded = {}
 
     for name, field in getFields(schema).items():
-        if HAS_RFC822 and IPrimaryField.providedBy(field):
+        if not primary and HAS_RFC822 and IPrimaryField.providedBy(field):
             continue
 
         if name not in data:


### PR DESCRIPTION
Fixes issue where creating a Mosaic page with pre-defined content layout with pre-defined rich text fields ended up having empty rich text fields, because the field is marked primary (as it should be, for proper rich text marshaling), and primary fields were never parsed from query string by default.