### PR TITLE
Implement `Tile.absolute_url()`

### DIFF
--- a/news/+canonicalheader.bugfix
+++ b/news/+canonicalheader.bugfix
@@ -1,0 +1,1 @@
+Implement `Tile.absolute_url()` to fix canonical header introduced in `plone.namedfile`. @petschki

--- a/plone/tiles/tile.py
+++ b/plone/tiles/tile.py
@@ -96,6 +96,9 @@ class Tile(BrowserView):
     def url(self):
         return absoluteURL(self, self.request)
 
+    def absolute_url(self):
+        return self.url
+
 
 @implementer(IPersistentTile)
 class PersistentTile(Tile):

--- a/plone/tiles/tiles.rst
+++ b/plone/tiles/tiles.rst
@@ -662,6 +662,13 @@ For convenience, the tile URL is also available under the ``url`` property:
     >>> transientTile.url
     'http://example.com/context/@@sample.tile/tile1?title=My+title&cssClass=foo&count%3Along=5'
 
+We also implement the ``absolute_url()`` method.
+
+.. code-block:: python
+
+    >>> transientTile.absolute_url()
+    'http://example.com/context/@@sample.tile/tile1?title=My+title&cssClass=foo&count%3Along=5'
+
 The tile absolute URL structure remains unaltered if the data is
 coming from a `_tiledata` JSON-encoded parameter instead of from the request
 parameters directly:


### PR DESCRIPTION
Fixes canonical header for file download and display. See https://github.com/plone/plone.namedfile/pull/163 ... came across this in https://github.com/plone/plone.app.standardtiles/pull/171